### PR TITLE
Use tar and md5 to check for changes in build_folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You need to have following programs installed in your $PATH:
 * md5sum or md5
 * aws
 * docker
+* tar
 
 **Note:** Docker server needs to be running so that we can actually build images
 

--- a/bin/folder_contents.sh
+++ b/bin/folder_contents.sh
@@ -5,6 +5,9 @@ set -e
 
 # List of arguments
 build_folder=$1
+exclude_tar_dirs='--exclude=".git" --exclude=".terraform"'
+
+which tar > /dev/null || { echo 'ERROR: tar is not installed' ; exit 1; }
 
 # Linux has command md5sum and OSX has command md5
 if command -v md5sum >/dev/null 2>&1; then
@@ -16,8 +19,14 @@ else
   exit 255
 fi
 
+## Check folder exists
+[ -d "$build_folder" ] || { echo "ERROR: Directory $build_folder not found" ; exit 1; }
+
+### Archive using git archive
+archive_cmd="tar -c $exclude_tar_dirs -f - $build_folder"
+
 # Take md5 from each object inside the program and then take a md5 of that output
-md5_output=$(eval $MD5_PROGRAM $build_folder/** | $MD5_PROGRAM )
+md5_output=$(eval $archive_cmd | $MD5_PROGRAM )
 
 # Output result as JSON back to terraform
 echo "{ \"md5\": \"$md5_output\" }"


### PR DESCRIPTION
Previously, md5 was only checking for changes in files of the root dir of build folder. 

Pulling in useful feature developed by Jaya Chandra.