### PR TITLE
Exclude addition files and dir

### DIFF
--- a/bin/folder_contents.sh
+++ b/bin/folder_contents.sh
@@ -5,7 +5,9 @@ set -e
 
 # List of arguments
 build_folder=$1
-exclude_tar_dirs='--exclude=".git" --exclude=".terraform"'
+exclude_tar_dirs_terraform='--exclude=".terraform" --exclude="*.tfstate*"'
+exclude_tar_dirs_general='--exclude=".git" --exclude="tests"'
+exclude_tar_dirs_python='--exclude=".pytest_cache" --exclude="tests" --exclude="__pycache__"'
 
 which tar > /dev/null || { echo 'ERROR: tar is not installed' ; exit 1; }
 
@@ -23,7 +25,7 @@ fi
 [ -d "$build_folder" ] || { echo "ERROR: Directory $build_folder not found" ; exit 1; }
 
 ### Archive using git archive
-archive_cmd="tar -c $exclude_tar_dirs -f - $build_folder"
+archive_cmd="tar -c $exclude_tar_dirs_terraform $exclude_tar_dirs_general $exclude_tar_dirs_python -f - $build_folder"
 
 # Take md5 from each object inside the program and then take a md5 of that output
 md5_output=$(eval $archive_cmd | $MD5_PROGRAM )

--- a/bin/folder_contents.sh
+++ b/bin/folder_contents.sh
@@ -5,9 +5,9 @@ set -e
 
 # List of arguments
 build_folder=$1
-exclude_tar_dirs_terraform='--exclude=".terraform" --exclude="*.tfstate*"'
+exclude_tar_dirs_terraform='--exclude=".terraform" --exclude=".terraform*" --exclude="*.tfstate*"'
 exclude_tar_dirs_general='--exclude=".git" --exclude="tests"'
-exclude_tar_dirs_python='--exclude=".pytest_cache" --exclude="tests" --exclude="__pycache__"'
+exclude_tar_dirs_python='--exclude=".pytest_cache" --exclude="__pycache__"'
 
 which tar > /dev/null || { echo 'ERROR: tar is not installed' ; exit 1; }
 


### PR DESCRIPTION
Extending the exclude logic to remove more files and directories that are not directly linked to code being deployed.